### PR TITLE
Lesson 27: Add Framebuffer and improve texture handling

### DIFF
--- a/src/main/java/com/github/jmitchell238/marioengine/components/SpriteRenderer.java
+++ b/src/main/java/com/github/jmitchell238/marioengine/components/SpriteRenderer.java
@@ -64,4 +64,9 @@ public class SpriteRenderer extends Component {
     public void setClean() {
         this.isDirty = false;
     }
+
+    public void setTexture(Texture texture) {
+        this.sprite.setTexture(texture);
+        this.isDirty = true;
+    }
 }

--- a/src/main/java/com/github/jmitchell238/marioengine/jade/Window.java
+++ b/src/main/java/com/github/jmitchell238/marioengine/jade/Window.java
@@ -1,5 +1,6 @@
 package com.github.jmitchell238.marioengine.jade;
 
+import com.github.jmitchell238.marioengine.renderer.Framebuffer;
 import org.lwjgl.Version;
 import org.lwjgl.glfw.GLFWErrorCallback;
 import org.lwjgl.opengl.GL;
@@ -14,10 +15,12 @@ import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.system.MemoryUtil.NULL;
 
 public class Window {
-    private int width, height;
+    private int width;
+    private int height;
     private String title;
     private long glfwWindow;
     private ImGuiLayer imGuiLayer;
+    private Framebuffer framebuffer;
 
     public float r, g, b, a;
     private boolean fadeToBlack = false;
@@ -145,6 +148,8 @@ public class Window {
         this.imGuiLayer = new ImGuiLayer(glfwWindow);
         this.imGuiLayer.initImGui();
 
+        this.framebuffer = new Framebuffer(1920, 1080);
+
         Window.changeScene(0);
     }
 
@@ -162,10 +167,14 @@ public class Window {
             glClearColor(r, g, b, a);
             glClear(GL_COLOR_BUFFER_BIT);
 
+//            this.framebuffer.bind();
+
             if(dt >= 0) {
                 DebugDraw.draw();
                 currentScene.update(dt);
             }
+
+            this.framebuffer.unbind();
 
             this.imGuiLayer.update(dt, currentScene);
             glfwSwapBuffers(glfwWindow);

--- a/src/main/java/com/github/jmitchell238/marioengine/renderer/Framebuffer.java
+++ b/src/main/java/com/github/jmitchell238/marioengine/renderer/Framebuffer.java
@@ -1,0 +1,47 @@
+package com.github.jmitchell238.marioengine.renderer;
+
+import lombok.Getter;
+
+import static org.lwjgl.opengl.GL30.*;
+
+public class Framebuffer {
+    @Getter
+    private int fboId = 0;
+
+    private Texture texture = null;
+
+    public Framebuffer(int width, int height) {
+        // Generate Framebuffer
+        fboId = glGenFramebuffers();
+        glBindFramebuffer(GL_FRAMEBUFFER, fboId);
+
+        // Create the texture to render the data to, and attach it to our framebuffer
+        this.texture = new Texture(width, height);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, this.texture.getId(), 0);
+
+        // Create the depth buffer and attach it to our framebuffer
+        int rboId = glGenRenderbuffers();
+        glBindRenderbuffer(GL_RENDERBUFFER, rboId);
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT32, width, height);
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rboId);
+
+        if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+            assert false : "Error: Framebuffer is not complete!";
+        }
+
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    }
+
+    public void bind() {
+        glBindFramebuffer(GL_FRAMEBUFFER, fboId);
+        glViewport(0, 0, this.texture.getWidth(), this.texture.getHeight());
+    }
+
+    public void unbind() {
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    }
+
+    public int getTextureId() {
+        return this.texture.getId();
+    }
+}

--- a/src/main/java/com/github/jmitchell238/marioengine/renderer/RenderBatch.java
+++ b/src/main/java/com/github/jmitchell238/marioengine/renderer/RenderBatch.java
@@ -67,7 +67,7 @@ public class RenderBatch implements Comparable<RenderBatch>{
         // Allocate space for vertices
         vboID = glGenBuffers();
         glBindBuffer(GL_ARRAY_BUFFER, vboID);
-        glBufferData(GL_ARRAY_BUFFER, vertices.length * Float.BYTES, GL_DYNAMIC_DRAW);
+        glBufferData(GL_ARRAY_BUFFER, (long) vertices.length * Float.BYTES, GL_DYNAMIC_DRAW);
 
         // Create and upload indices buffer
         int eboID = glGenBuffers();
@@ -95,10 +95,8 @@ public class RenderBatch implements Comparable<RenderBatch>{
         this.sprites[index] = spr;
         this.numSprites++;
 
-        if (spr.getTexture() != null) {
-            if (!textures.contains(spr.getTexture())) {
-                textures.add(spr.getTexture());
-            }
+        if (spr.getTexture() != null && !textures.contains(spr.getTexture())) {
+            textures.add(spr.getTexture());
         }
 
         // Add properties to local vertices array
@@ -190,7 +188,7 @@ public class RenderBatch implements Comparable<RenderBatch>{
         int texId = 0;
         if (sprite.getTexture() != null) {
             for (int i = 0; i < textures.size(); i++) {
-                if (textures.get(i) == sprite.getTexture()) {
+                if (textures.get(i).equals(sprite.getTexture())) {
                     texId = i + 1;
                     break;
                 }

--- a/src/main/java/com/github/jmitchell238/marioengine/renderer/Texture.java
+++ b/src/main/java/com/github/jmitchell238/marioengine/renderer/Texture.java
@@ -1,5 +1,6 @@
 package com.github.jmitchell238.marioengine.renderer;
 
+import lombok.Getter;
 import org.lwjgl.BufferUtils;
 
 import java.nio.ByteBuffer;
@@ -9,9 +10,31 @@ import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.stb.STBImage.*;
 
 public class Texture {
+    @Getter
     private String filepath;
-    private int texID;
-    private int width, height;
+    private transient int texID;
+    @Getter
+    private int width;
+    @Getter
+    private int height;
+
+    public Texture() {
+        this.filepath = "";
+        this.texID = -1;
+        this.width = -1;
+        this.height = -1;
+    }
+
+    public Texture(int width, int height) {
+        this.filepath = "Generated";
+
+        // Generate texture on GPU
+        texID = glGenTextures();
+        glBindTexture(GL_TEXTURE_2D, texID);
+
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, width, height,
+                0, GL_RGB, GL_UNSIGNED_BYTE, 0);
+    }
 
     public void init(String filepath) {
         this.filepath = filepath;
@@ -63,15 +86,15 @@ public class Texture {
         glBindTexture(GL_TEXTURE_2D, 0);
     }
 
-    public int getWidth() {
-        return this.width;
-    }
-
-    public int getHeight() {
-        return this.height;
-    }
-
     public int getId() {
         return this.texID;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        if (!(o instanceof Texture)) return false;
+        Texture t = (Texture) o;
+        return t.getWidth() == this.width && t.getHeight() == this.height && t.getId() == this.texID && t.getFilepath().equals(this.filepath);
     }
 }

--- a/src/main/java/com/github/jmitchell238/marioengine/scenes/LevelEditorScene.java
+++ b/src/main/java/com/github/jmitchell238/marioengine/scenes/LevelEditorScene.java
@@ -35,7 +35,9 @@ public class LevelEditorScene extends Scene {
         this.sprites = AssetPool.getSpriteSheet("assets/images/spritesheets/decorationsAndBlocks.png");
 
         if(levelLoaded) {
-            this.activeGameObject = gameObjects.get(0);
+            if(!gameObjects.isEmpty()) {
+                this.activeGameObject = gameObjects.get(0);
+            }
             return;
         }
 
@@ -67,6 +69,15 @@ public class LevelEditorScene extends Scene {
                         16, 16, 81, 0));
 
         AssetPool.getTexture("assets/images/blendImage2.png");
+
+        for(GameObject g : gameObjects) {
+            if(g.getComponent(SpriteRenderer.class) != null) {
+                SpriteRenderer spr = g.getComponent(SpriteRenderer.class);
+                if(spr.getTexture() != null) {
+                    spr.setTexture(AssetPool.getTexture(spr.getTexture().getFilepath()));
+                }
+            }
+        }
     }
 
 //    float x = 0.0f;


### PR DESCRIPTION
## Mario 2D Gaming Engine

---
### Reason for Work
- [x] New Completed Lesson
- [ ] Bug Fix
- [ ] Refactor Work
- [ ] Updated Build / Framework / Language settings

---
### Description of Work:
- Added a new `Framebuffer class` to improve graphics rendering, specifically for off-screen rendering. 
- `Framebuffer class` was added in the renderer package. 
- Modified the Texture class to handle generating a texture with a specific width and height without needing an existing file. 
- Modified `SpriteRenderer` and `LevelEditorScene` to refresh the texture of game objects after loading new files. 
- Also, added an equals method in the `texture class` to properly handle texture comparisons which improves visual consistency. 
- Improved texture indexing in `RenderBatch.java` for sprites using the new equals method and updated `widow.java` to create a new `Framebuffer` object and bind it to the render operation.

---
### Lesson # and Name
    Lesson 27 - Framebuffers in OpenGL

---
### Language
    Java

---
### Direct Link to Lesson
[Click here to go to Lesson](https://youtu.be/lALvR4j6RCM?si=zmEKaWIV8CmKd-J4)

---
### Tests
- [ ] Test Created
- [ ] Test Passing
